### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ backports.ssl-match-hostname==3.4.0.2
 future==0.15.0
 requests==2.7.0
 six==1.9.0
-websocket-client==0.32.0
+websocket-client==0.36.0


### PR DESCRIPTION
Old version of websocket-client has many bugs that were fixed. Some were causing issues in dependencies like this one docker/dockercloud-haproxy#15