### PR TITLE
Reconnection feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ target/
 # IDE
 .idea/
 
+# vim
+*.swp
+
 venv/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ The authentication can be configured in the following ways:
 		export DOCKERCLOUD_USER=username
 		export DOCKERCLOUD_APIKEY=apikey
 
+## Optional parameters
+
+You may set the reconnection interval (Integer, in seconds) using the variable DOCKERCLOUD_RECONNECTION_INTERVAL:
+
+		export DOCKERCLOUD_RECONNECTION_INTERVAL=240
+
+Session uses a socket that may be closed by some peer. To prevent the "Read timed out" issue you should use this option.
+
+Possible values:
+
+* `-1` (by default) means no reconnect (as usually it works)
+* `0` means reconnect on each request
+* any positive value means that the connection will be reopened if the time diff between last 2 requests is more than that value
+
 ## Namespace
 
 To support teams and orgs, you can specify the namespace in the following ways:

--- a/dockercloud/__init__.py
+++ b/dockercloud/__init__.py
@@ -40,6 +40,8 @@ stream_host = os.environ.get("DOCKERCLOUD_STREAM_HOST") or 'wss://ws.cloud.docke
 
 namespace = os.environ.get('DOCKERCLOUD_NAMESPACE')
 
+reconnection_interval = int(os.environ.get('DOCKERCLOUD_RECONNECTION_INTERVAL', '-1')) # in seconds, if the connection is inactive more than that value it will be recreated
+
 user_agent = None
 
 logging.basicConfig()

--- a/dockercloud/api/http.py
+++ b/dockercloud/api/http.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import time
 
 from requests import Request, Session
 from requests import utils
@@ -12,9 +13,14 @@ from .exceptions import ApiError, AuthError
 logger = logging.getLogger("python-dockercloud")
 
 global_session = Session()
+last_connection_time = time.time()
 
-
-def get_session():
+def get_session(time=time):
+    if (dockercloud.reconnection_interval >= 0):
+        global last_connection_time
+        if (time.time() - last_connection_time > dockercloud.reconnection_interval):
+            new_session()
+        last_connection_time = time.time()
     return global_session
 
 

--- a/tests/test_http_reconnection.py
+++ b/tests/test_http_reconnection.py
@@ -1,0 +1,63 @@
+import unittest
+import time
+import dockercloud
+from dockercloud.api import http
+
+_reconnection_interval = None
+
+class FakeTime(object):
+    def __init__(self, val=None):
+        self.val = val
+    def time(self):
+        return self.val
+
+class SessionReconnectionTestCase(unittest.TestCase):
+    # a few helpers
+    def setUp(self):
+        global _reconnection_interval
+        global _last_connection_time
+        _reconnection_interval = dockercloud.reconnection_interval
+        _last_connection_time = http.last_connection_time
+        http.last_connection_time = 0
+
+    def tearDown(self):
+        global old_reconnection_interval
+        global _last_connection_time
+        dockercloud.reconnection_interval = _reconnection_interval
+        dockercloud.http = _last_connection_time
+    #
+
+    def test_logic_without_interval(self):
+        dockercloud.reconnection_interval = None
+        session1 = http.get_session()
+        session2 = http.get_session()
+        self.assertEqual(id(session1), id(session2))
+
+    def test_logic_with_negative_interval(self):
+        dockercloud.reconnection_interval = -1
+        session1 = http.get_session()
+        session2 = http.get_session()
+        self.assertEqual(id(session1), id(session2))
+
+    def test_logic_with_zero_interval(self):
+        dockercloud.reconnection_interval = 0
+        session1 = http.get_session()
+        session2 = http.get_session()
+        self.assertNotEqual(id(session1), id(session2))
+
+    def test_logic_with_positive_interval(self):
+        dockercloud.reconnection_interval = 30
+
+        # diff is less than 30 secs
+        session1 = http.get_session(FakeTime(0))
+        session2 = http.get_session(FakeTime(10))
+        self.assertEqual(id(session1), id(session2))
+
+        # diff is equal to 30 secs
+        session3 = http.get_session(FakeTime(40))
+        self.assertEqual(id(session2), id(session3))
+
+        # diff is more that 30 secs
+        session4 = http.get_session(FakeTime(71))
+        self.assertNotEqual(id(session3), id(session4))
+


### PR DESCRIPTION
Some of cloud providers are terminating long running connections (eg for MS Azure it's 4min default). So in this case a socket (which is created by the main Session object) may be closed and client will get this error https://www.dropbox.com/s/t2obll61wdzrxdq/Screen%20Shot%202017-01-03%20at%2003.23.57.png?dl=0
So, this issue may be prevented if the connection is reopened in some interval.
Looking forward to merging this PR, thank you.