### PR TITLE
Fix #23: Use event instead of message

### DIFF
--- a/dockercloud/api/events.py
+++ b/dockercloud/api/events.py
@@ -33,7 +33,7 @@ class Events(StreamingAPI):
             return
 
         if self.message_handler:
-            self.message_handler(message)
+            self.message_handler(event)
 
     def _on_error(self, ws, e):
         if isinstance(e, websocket._exceptions.WebSocketBadStatusException) and getattr(e, "status_code") == 401:


### PR DESCRIPTION
Use event instead of message because I believe that is the intended behavior.