### PR TITLE
exclude tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open('./test-requirements.txt') as test_reqs_txt:
 setup(
         name="python-dockercloud",
         version=find_version('dockercloud', '__init__.py'),
-        packages=find_packages(),
+        packages=find_packages(exclude=['tests']),
         install_requires=requirements,
         tests_require=test_requirements,
         provides=['docker'],


### PR DESCRIPTION
When installing python-dockercloud with pip on Arch Linux via `pip2 install python-dockercloud`it polluts the global namespace by installing its tests to `/usr/lib/python2.7/site-packages/tests/`. 
```
user$ ll /usr/lib/python2.7/site-packages/tests/
insgesamt 488K
-rw-r--r-- 1 root root  62K 28. Mär 19:01 fake_api.py
-rw-r--r-- 1 root root  66K 28. Mär 19:01 fake_api.pyc
-rw-r--r-- 1 root root  391 28. Mär 19:01 __init__.py
-rw-r--r-- 1 root root  431 28. Mär 19:01 __init__.pyc
-rw-r--r-- 1 root root 3,6K 28. Mär 19:01 test_action.py
-rw-r--r-- 1 root root 4,1K 28. Mär 19:01 test_action.pyc
-rw-r--r-- 1 root root 3,2K 28. Mär 19:01 test_auth.py
-rw-r--r-- 1 root root 3,6K 28. Mär 19:01 test_auth.pyc
-rw-r--r-- 1 root root 9,7K 28. Mär 19:01 test_base.py
-rw-r--r-- 1 root root  10K 28. Mär 19:01 test_base.pyc
-rw-r--r-- 1 root root  70K 18. Mai 2016  test_commands.py
-rw-r--r-- 1 root root  17K 28. Mär 19:01 test_container.py
-rw-r--r-- 1 root root  17K 28. Mär 19:01 test_container.pyc
-rw-r--r-- 1 root root 1,4K 28. Mär 19:01 test_http.py
-rw-r--r-- 1 root root 2,4K 28. Mär 19:01 test_http.pyc
-rw-r--r-- 1 root root 6,0K 28. Mär 19:01 test_nodecluster.py
-rw-r--r-- 1 root root 6,5K 28. Mär 19:01 test_nodecluster.pyc
-rw-r--r-- 1 root root 2,1K 28. Mär 19:01 test_nodeprovider.py
-rw-r--r-- 1 root root 2,7K 28. Mär 19:01 test_nodeprovider.pyc
-rw-r--r-- 1 root root 5,6K 28. Mär 19:01 test_node.py
-rw-r--r-- 1 root root 6,3K 28. Mär 19:01 test_node.pyc
-rw-r--r-- 1 root root 5,5K 28. Mär 19:01 test_noderegion.py
-rw-r--r-- 1 root root 6,0K 28. Mär 19:01 test_noderegion.pyc
-rw-r--r-- 1 root root 6,4K 28. Mär 19:01 test_nodetype.py
-rw-r--r-- 1 root root 6,8K 28. Mär 19:01 test_nodetype.pyc
-rw-r--r-- 1 root root  22K  8. Feb 2016  test_parser.py
-rw-r--r-- 1 root root 5,0K 28. Mär 19:01 test_repository.py
-rw-r--r-- 1 root root 5,7K 28. Mär 19:01 test_repository.pyc
-rw-r--r-- 1 root root  24K 28. Mär 19:01 test_service.py
-rw-r--r-- 1 root root  24K 28. Mär 19:01 test_service.pyc
-rw-r--r-- 1 root root  13K 28. Mär 19:01 test_utils.py
-rw-r--r-- 1 root root 5,8K 28. Mär 19:01 test_utils.pyc
```

This then conflicts with https://github.com/docker/dockercloud-cli, because this package does the same.

This PR solves the issue by excluding the `tests`-directory when installing the package. Another solution would be to move the directory into the `dockercloud` subdirectory, but this breaks the tests and I don't know how to fix that.